### PR TITLE
Add function: `dispose`

### DIFF
--- a/Notifwift/Notifwift.swift
+++ b/Notifwift/Notifwift.swift
@@ -83,11 +83,9 @@ public final class Notifwift {
     }
     
     private func removeFromPool(name: String) {
-        pool.filter{ $0.name == name}.forEach { ObserverContainer in
-            if let index = pool.indexOf({ $0.name == ObserverContainer.name}) {
-                NSNotificationCenter.defaultCenter().removeObserver(ObserverContainer.observer)
-                pool.removeAtIndex(index)
-            }
+        pool.enumerate().filter { $0.element.name == name }.reverse().forEach { index, container in
+            NSNotificationCenter.defaultCenter().removeObserver(container.observer)
+            pool.removeAtIndex(index)
         }
     }
     

--- a/Notifwift/Notifwift.swift
+++ b/Notifwift/Notifwift.swift
@@ -40,7 +40,6 @@ public final class Notifwift {
     }
     
     private var pool = [ObserverContainer]()
-    private let nc = NSNotificationCenter.defaultCenter()
     
     public init() {}
 
@@ -77,7 +76,7 @@ public final class Notifwift {
     private func addToPool(name: String, from object: AnyObject?=nil, queue: NSOperationQueue?=nil, block: (NSNotification) -> Void) {
         let container = ObserverContainer(
             name: name,
-            observer: nc.addObserverForName(name, object: object, queue: queue, usingBlock: block)
+            observer: NSNotificationCenter.defaultCenter().addObserverForName(name, object: object, queue: queue, usingBlock: block)
         )
         pool.append(container)
     }

--- a/Notifwift/Notifwift.swift
+++ b/Notifwift/Notifwift.swift
@@ -24,41 +24,79 @@ import Foundation
 
 public final class Notifwift {
     private final class Container {
+        static let Key = "container"
+        
         let payload: Any
         init(payload: Any) { self.payload = payload }
     }
-    private var pool = [NSObjectProtocol]()
-
+    
+    private final class PoolContainer {
+        private let name: String
+        private let observer: NSObjectProtocol
+        init(name: String, observer: NSObjectProtocol) {
+            self.name = name
+            self.observer = observer
+        }
+    }
+    
+    private var pool = [PoolContainer]()
+    private let nc = NSNotificationCenter.defaultCenter()
+    
     public init() {}
 
     public static func post(name: String, from object: NSObject?=nil, payload: Any?=nil) {
         NSNotificationCenter.defaultCenter().postNotificationName(name,
             object: object,
-            userInfo: payload.map { ["container": Container(payload: $0)] }
+            userInfo: payload.map { [Container.Key: Container(payload: $0)] }
         )
     }
-    public func observe(name: String, from object: AnyObject?=nil, queue: NSOperationQueue?=nil, block:(notification:NSNotification) -> Void) {
-        pool.append(
-            NSNotificationCenter.defaultCenter().addObserverForName(name, object: object, queue: queue, usingBlock: block)
-        )
+    
+    public func observe(name: String, from object: AnyObject?=nil, queue: NSOperationQueue?=nil, block: (notification:NSNotification) -> Void) {
+        addToPool(name, from: object, queue: queue, block: block)
     }
-    public func observe<T>(name: String, from object: AnyObject?=nil, queue: NSOperationQueue?=nil, block:(notification:NSNotification, payload: T) -> Void) {
-        pool.append(
-            NSNotificationCenter.defaultCenter().addObserverForName(name, object: object, queue: queue) {
-                guard let payload = ($0.userInfo?["container"] as? Container)?.payload as? T else { return }
-                block(notification: $0, payload: payload)
+    
+    public func observe<T>(name: String, from object: AnyObject?=nil, queue: NSOperationQueue?=nil, block: (notification:NSNotification, payload: T) -> Void) {
+        addToPool(name, from: object, queue: queue) { [weak self] in
+            guard let payload = self?.payloadFromNotification($0) as? T else { return }
+            block(notification: $0, payload: payload)
+        }
+    }
+    
+    public func observe<T>(name: String, from object: AnyObject?=nil, queue: NSOperationQueue?=nil, block: (payload: T) -> Void) {
+        addToPool(name, from: object, queue: queue) { [weak self] in
+            guard let payload = self?.payloadFromNotification($0) as? T else { return }
+            block(payload: payload)
+        }
+    }
+    
+    public func dispose(name: String) {
+        removeFromPool(name)
+    }
+    
+    // MARK: private methods
+    private func addToPool(name: String, from object: AnyObject?=nil, queue: NSOperationQueue?=nil, block: (NSNotification) -> Void) {
+        let container = PoolContainer(
+            name: name,
+            observer: nc.addObserverForName(name, object: object, queue: queue, usingBlock: block)
+        )
+        pool.append(container)
+    }
+    
+    private func removeFromPool(name: String) {
+        pool.filter{ $0.name == name}.forEach { poolContainer in
+            if let index = pool.indexOf({ $0.name == poolContainer.name}) {
+                NSNotificationCenter.defaultCenter().removeObserver(poolContainer.observer)
+                pool.removeAtIndex(index)
             }
-        )
+        }
     }
-    public func observe<T>(name: String, from object: AnyObject?=nil, queue: NSOperationQueue?=nil, block:(payload: T) -> Void) {
-        pool.append(
-            NSNotificationCenter.defaultCenter().addObserverForName(name, object: object, queue: queue) {
-                guard let payload = ($0.userInfo?["container"] as? Container)?.payload as? T else { return }
-                block(payload: payload)
-            }
-        )
+    
+    private func payloadFromNotification(notification: NSNotification) -> Any? {
+        return (notification.userInfo?[Container.Key] as? Container)?.payload
     }
+    
     deinit {
-        pool.forEach { NSNotificationCenter.defaultCenter().removeObserver($0) }
+        pool.forEach { NSNotificationCenter.defaultCenter().removeObserver($0.observer) }
+        pool.removeAll()
     }
 }

--- a/NotifwiftTests/NotifwiftTests.swift
+++ b/NotifwiftTests/NotifwiftTests.swift
@@ -142,4 +142,67 @@ class NotifwiftTests: XCTestCase {
         XCTAssertFalse(receivedFromObj1!)
         XCTAssertTrue(receivedFromObj2!)
     }
+    
+    func testDispose() {
+        var payloadStr: Any?
+        var payloadInt: Any?
+        
+        let nt = Notifwift()
+        nt.observe(notificationName) { (p:String) in
+            payloadStr = p
+        }
+        nt.observe(notificationName) { (p:Int) in
+            payloadInt = p
+        }
+        
+        payloadStr = nil
+        payloadInt = nil
+        Notifwift.post(notificationName, payload:"aaaa")
+        Notifwift.post(notificationName, payload:1111)
+        XCTAssertEqual(payloadStr as? String, "aaaa")
+        XCTAssertEqual(payloadInt as? Int, 1111)
+        
+        payloadStr = nil
+        payloadInt = nil
+        nt.dispose(notificationName)
+        Notifwift.post(notificationName, payload:"aaaa")
+        Notifwift.post(notificationName, payload:1111)
+        XCTAssertNil(payloadStr)
+        XCTAssertNil(payloadInt)
+        
+        var received: Bool?
+        var receivedFromObj1: Bool?
+        var receivedFromObj2: Bool?
+        
+        // MARK: with `from` object.
+        let obj1 = NSObject()
+        let obj2 = NSObject()
+        nt.observe(notificationName) { _ in
+            received = true
+        }
+        nt.observe(notificationName, from: obj1) { _ in
+            receivedFromObj1 = true
+        }
+        nt.observe(notificationName, from: obj2) { _ in
+            receivedFromObj2 = true
+        }
+        
+        received = false
+        receivedFromObj1 = false
+        receivedFromObj2 = false
+        Notifwift.post(notificationName, from: obj1)
+        XCTAssertTrue(received!)
+        XCTAssertTrue(receivedFromObj1!)
+        XCTAssertFalse(receivedFromObj2!)
+        
+        received = false
+        receivedFromObj1 = false
+        receivedFromObj2 = false
+        nt.dispose(notificationName)
+        Notifwift.post(notificationName, from: obj2)
+        XCTAssertFalse(received!)
+        XCTAssertFalse(receivedFromObj1!)
+        XCTAssertFalse(receivedFromObj2!)
+
+    }
 }


### PR DESCRIPTION
Added function `dispose(name:String)`.
- Add PoolContainer.
- Refacor and clean up code.
- Add tests for dispose and all tests passed!

---

(一応日本語で詳細追記します。)

勝手ながら、observeした通知を、その時に投げた通知名を使って解除できる`dispose`メソッドを実装してみました。
現行のものだと、オブジェクトを破棄するまでobserveしたものが破棄されないので、あるタイミングで解除したい場合にインスタンスを丸ごと破棄しないといけなかったので、`dispose`メソッドとして追加しました。

本当は、名前を投げて解除するパターンと、名前とfrom objectを投げて解除するパターンの2つを、removeObserverメソッドに倣って用意しようと思いましたが、object指定までしてしまうと、AnyやAnyObjectだとEquatableが採用されてないので難しく、Equatableを採用した場合は、自作class、enum、structにEquatableの採用を強いる事になるので見送りました。この辺りは設計次第で導入してもいいかもしれないです。
なので、現状は同じ通知名で、from objectが異なる場合、どちらも解除されてしまいます。

あとは少しリファクタリングかけたりも勝手にやってしまったので、気に入らなければ直したり、このPRをマージせずにこのPRからブランチ切って直したり、必要な部分だけ抽出したりして作り変えてください！
もし何かあればご連絡ください。

一応dispose実装とリファクタリングに伴って、テスト記述+テスト通過確認済みです。
