### PR TITLE
Use Any instead of NSObject

### DIFF
--- a/Notifwift/Notifwift.swift
+++ b/Notifwift/Notifwift.swift
@@ -52,7 +52,7 @@ public final class Notifwift {
     
     public init() {}
 
-    public static func post(_ name: Notification.Name, from object: NSObject? = nil, payload: Any? = nil) {
+    public static func post(_ name: Notification.Name, from object: Any? = nil, payload: Any? = nil) {
         NotificationCenter.default.post(
             name: name,
             object: object,


### PR DESCRIPTION
Remaining fix of `AnyObject -> Any` #8
